### PR TITLE
feat: Implementa função para formatar moedas

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,11 @@
+export const formatValue = 
+    (
+        value: string | number, 
+        locale: string = 'pt-BR',
+        currency: string = 'BRL'
+    ) : string => {
+            return Intl.NumberFormat(locale, { 
+                style: 'currency',
+                currency: currency }
+            ).format( typeof value === 'string' ? parseFloat(value) : value );
+}


### PR DESCRIPTION
A função aceita três parâmetros;
```value```, do tipo string ou number
```locale```, do tipo string com o valor default ```pt-BR```
```currency```, do tipo string com o valor default ```BRL```.